### PR TITLE
Remove extra sorting of 4D intervals (#34)

### DIFF
--- a/webviz_4d/_private_plugins/surface_selector.py
+++ b/webviz_4d/_private_plugins/surface_selector.py
@@ -80,7 +80,7 @@ class SurfaceSelector:
 
     def _interval_in_attr(self):
         map_type = self.map_defaults["map_type"]
-        return unique_values(self.selections[map_type]["interval"])
+        return self.selections[map_type]["interval"]
 
     @property
     def attribute_selector(self):


### PR DESCRIPTION
The 4D intervals are already sorted in a data preparation script (compile_ maps_metadata.py) so they should not be sorted again